### PR TITLE
Update template_os_linux_by_zabbix_agent_active.xml

### DIFF
--- a/Templates/Operating Systems/Linux/template_os_linux_by_zabbix_agent_active.xml
+++ b/Templates/Operating Systems/Linux/template_os_linux_by_zabbix_agent_active.xml
@@ -1473,7 +1473,7 @@ https://github.com/krom/zabbix_template_md</description>
                             <snmpv3_authpassphrase/>
                             <snmpv3_privprotocol>0</snmpv3_privprotocol>
                             <snmpv3_privpassphrase/>
-                            <params>forecast(&quot;vfs.fs.inode[{#FSNAME},free]&quot;,12h,,12h)</params>
+                            <params>last(&quot;vfs.fs.inode[{#FSNAME},total]&quot;) - forecast(&quot;vfs.fs.inode[{#FSNAME},free]&quot;,12h,,12h)</params>
                             <ipmi_sensor/>
                             <authtype>0</authtype>
                             <username/>


### PR DESCRIPTION
Used inodes for 12h linear forecast was showing Free inodes for 12h linear forecast instead. Changed!