### PR TITLE
Update Zabbix pathname in README

### DIFF
--- a/Template Microsoft Hyper-V/readme.md
+++ b/Template Microsoft Hyper-V/readme.md
@@ -2,34 +2,41 @@
 
 # Features
 
-Monitoring and LLD : Guest/Root CPU, RAM, Ratio CPU/RAM, Host Virtual Network adapters and switches, Virtual machine storage and network
-Inventory:count VM, states, health  
-Screen System performance: CPU, Memory, Networks, VHDX 
-Independent OS language  
-Setting configuring by User Macros  
-You can analyzing all performance data overall host and virtual machines
+* Monitoring and LLD: Guest/Root CPU, RAM, Ratio CPU/RAM, Host Virtual Network adapters and switches, Virtual machine storage and network
+* Inventory: count VM, states, health  
+* Screen System performance: CPU, Memory, Networks, VHDX 
+* Independent OS language  
+* Setting configuring by User Macros  
+* You can analyzing all performance data overall host and virtual machines
 
 # Requirements
-Hyper-V: Windows server 2008 R2 or higher  
-PowerShell 3  
+* Hyper-V: Windows server 2008 R2 or higher  
+* PowerShell 3  
 
-# How install
-1. Import the template XML file using the Zabbix Templates Import feature.
+# Install
+1. On the server, import the template XML file using the Zabbix Templates Import feature (Administration > Proxies > Create proxy)
 
-2. Create host and set Template
+2. On the server, create Host and set Template
 
-3. Create 2 folders in zabbix agent folder:
-\scripts\  
-\zabbix_agentd\  
-and copy the files  
-hyperv_host.ps1 to \scripts\  
-hyperv_host.conf to \zabbix_agentd\  
+3. On the client, enter in `C:\Program Files\Zabbix Agent` and create 2 directories:
 
-4. Add lines to zabbix.conf
+* `\scripts\`
+    * Then copy the `.ps1` file here
+* `\zabbix_agentd\`
+    * Then copy the `.conf` file here
 
-Include=C:\Program Files\zabbix-agent\zabbix_agentd\\*.conf  
+At the end you should have:
+
+* `C:\Program Files\Zabbix Agent\scripts\hyperv_host.ps1`
+* `C:\Program Files\Zabbix Agent\zabbix_agentd\hyperv_host.conf`
+
+4. On the client, add these lines to your `zabbix_agentd.conf`:
+
+```
+Include=C:\Program Files\Zabbix Agent\*.conf  
 UnsafeUserParameters=1  
-Timeout=10  
+Timeout=10
+```
 
 5. Restart Zabbix Agent
 6. All triggers you may change through user macros in host


### PR DESCRIPTION
I was helping a colleague over the phone who couldn't test this setup. I don't usually do these things on Microsoft Windows but... anyway his problem was about the `C:\Program Files\Zabbix Agent` pathname that now is the default one instead of `C:\Program Files\zabbix_agent` so I've updated it.

Other cosmetic changes.